### PR TITLE
Migrating to the newest available version pytest

### DIFF
--- a/bddrest/__init__.py
+++ b/bddrest/__init__.py
@@ -7,5 +7,5 @@ from .authoring import Given, when, story, response, Story, Append, Update, \
 from .exceptions import InvalidUrlParametersError, CallVerifyError
 
 
-__version__ = '2.1.5'
+__version__ = '2.2.0'
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ with open(join(dirname(__file__), 'bddrest', '__init__.py')) as v_file:
 
 dependencies = [
     'pyyaml',
-    'argcomplete'
+    'argcomplete',
+    'pytest >= 4.0.2',
 ]
 
 


### PR DESCRIPTION
Migrating to `pytest >= 4.0.2`